### PR TITLE
feat: MCP server, Claude Code plugin, reference profile v2.1.0

### DIFF
--- a/.claude-plugin/hooks/pre-pack-validate.sh
+++ b/.claude-plugin/hooks/pre-pack-validate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Pre-pack validation hook — runs before any pack operation.
+set -e
+SOURCE_DIR="${1:-_extracted}"
+echo "[pre-pack] Validating $SOURCE_DIR..."
+node src/index.js validate "$SOURCE_DIR"
+echo "[pre-pack] Validation passed."

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "opendeck-factory",
+  "tagline": "Generate Stream Deck profiles from code — no manual button setup",
+  "categories": ["developer-tools", "productivity", "stream-deck"],
+  "tags": ["stream-deck", "elgato", "profile-generator", "automation"],
+  "homepage": "https://github.com/thisis-romar/opendeck-factory",
+  "license": "FSL-1.1-ALv2",
+  "upsell": {
+    "text": "Premium icon packs and pre-built app profiles available in the catalog",
+    "url": "https://github.com/thisis-romar/stream-deck-catalog"
+  },
+  "distribution": [
+    "claudemarketplaces.com",
+    "claudeskills.info",
+    "skillsmp.com",
+    "awesome-claude-skills"
+  ]
+}

--- a/.claude-plugin/mcp/opendeck-factory-mcp.js
+++ b/.claude-plugin/mcp/opendeck-factory-mcp.js
@@ -1,0 +1,3 @@
+// Entry point alias — Claude Desktop resolves this path from plugin.json.
+// The actual server is in src/mcp-server.js.
+import '../../src/mcp-server.js';

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "opendeck-factory",
+  "displayName": "OpenDeck — Stream Deck Profile Generator",
+  "version": "2.1.0",
+  "description": "Programmatically create, edit, validate, and pack Elgato Stream Deck profiles. Generate color-coded icons from shortcut definitions.",
+  "skills": [
+    "../.claude/skills/generate-profile/SKILL.md"
+  ],
+  "mcpServers": {
+    "opendeck": {
+      "command": "node",
+      "args": ["src/mcp-server.js"]
+    }
+  },
+  "hooks": {
+    "PreToolUse[Bash(node src/index.js pack*)]": "bash .claude-plugin/hooks/pre-pack-validate.sh"
+  }
+}

--- a/.claude/skills/capture-streamdeck-reference/SKILL.md
+++ b/.claude/skills/capture-streamdeck-reference/SKILL.md
@@ -94,28 +94,35 @@ To add an action type not yet in the reference profile:
 | 1 | 0 | `com.elgato.streamdeck.system.hotkeyswitch` | Hotkey Switch |
 | 2 | 0 | `com.elgato.streamdeck.system.hotkey` | Hotkey Ctrl+A |
 | 3 | 0 | `com.elgato.streamdeck.system.open` | Open |
-| 4 | 0 | `com.elgato.streamdeck.system.openapp` | Open App |
+| 4 | 0 | `com.elgato.streamdeck.page.indicator` (app-rendered) | Page Indicator |
 | 0 | 1 | `com.elgato.streamdeck.system.close` | Close |
 | 1 | 1 | `com.elgato.streamdeck.system.text` | Text |
-| 2 | 1 | `com.elgato.streamdeck.system.multimedia` (actionIdx:0) | Prev Track |
-| 3 | 1 | `com.elgato.streamdeck.system.multimedia` (actionIdx:1) | Play/Pause |
-| 4 | 1 | `com.elgato.streamdeck.system.multimedia` (actionIdx:2) | Next Track |
+| 2 | 1 | `com.elgato.streamdeck.system.openapp` | Open App |
+| 3 | 1 | `com.elgato.streamdeck.system.multimedia` (actionIdx:0) | Prev Track |
+| 4 | 1 | `com.elgato.streamdeck.system.multimedia` (actionIdx:1) | Play/Pause |
 | 0 | 2 | `com.elgato.streamdeck.page` (nav) | ← Prev Page |
-| 1 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:3) | Stop |
-| 2 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:4) | Mute |
-| 3 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:5) | Vol+ |
+| 1 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:2) | Next Track |
+| 2 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:3) | Stop |
+| 3 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:4) | Mute |
 | 4 | 2 | `com.elgato.streamdeck.page` (nav) | Next Page → |
 
 ### Page 2 — Stream Deck (vivid orange)
 | Col | Row | Action ID | Label |
 |-----|-----|-----------|-------|
 | 0 | 0 | `com.elgato.streamdeck.system.timer` | Timer |
-| 1–4 | 0 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:0–3) | Brighter/Darker/Max/High |
-| 0–2 | 1 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:4–6) | Medium/Low/Minimum |
+| 1 | 0 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:0) | Brighter |
+| 2 | 0 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:1) | Darker |
+| 3 | 0 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:2) | Max |
+| 4 | 0 | `com.elgato.streamdeck.page.indicator` (app-rendered) | Page Indicator |
+| 0 | 1 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:4) | Medium |
+| 1 | 1 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:5) | Low |
+| 2 | 1 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:6) | Minimum |
 | 3 | 1 | `com.elgato.streamdeck.system.sleep` | Sleep |
 | 4 | 1 | `com.elgato.streamdeck.vsdtoggle` | Toggle VSD |
 | 0 | 2 | `com.elgato.streamdeck.page` (nav) | ← Prev Page |
-| 1 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:6) | Vol- |
+| 1 | 2 | `com.elgato.streamdeck.system.keybrightness` (actionIdx:3) | High |
+| 2 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:6) | Vol- |
+| 3 | 2 | `com.elgato.streamdeck.system.multimedia` (actionIdx:5) | Vol+ |
 | 4 | 2 | `com.elgato.streamdeck.page` (nav) | Next Page → |
 
 ### Page 3 — Navigation (vivid emerald)
@@ -123,11 +130,11 @@ To add an action type not yet in the reference profile:
 |-----|-----|-----------|-------|
 | 0 | 0 | `com.elgato.streamdeck.profile.rotate` | Switch Profile |
 | 1 | 0 | `com.elgato.streamdeck.page.goto` | Go to Page |
+| 4 | 0 | `com.elgato.streamdeck.page.indicator` (app-rendered) | Page Indicator |
 | 0 | 1 | `com.elgato.streamdeck.profile.backtoparent` | Parent Folder |
 | 0 | 2 | `com.elgato.streamdeck.page` (nav) | ← Prev Page |
 | 4 | 2 | `com.elgato.streamdeck.page` (nav) | Next Page → |
 | GUI only | — | `com.elgato.streamdeck.profile.openchild` | Create Folder (see GUI Capture table) |
-| GUI only | — | `com.elgato.streamdeck.page.indicator` | Page Indicator (see GUI Capture table) |
 
 ### Page 4 — Soundboard + Multi Act + Keys (vivid violet)
 | Col | Row | Action ID | Label |
@@ -136,26 +143,29 @@ To add an action type not yet in the reference profile:
 | 1 | 0 | `com.elgato.streamdeck.soundboard.stopaudioplay` | Stop Audio |
 | 2 | 0 | `com.elgato.streamdeck.multiactions.routine` | Multi Action |
 | 3 | 0 | `com.elgato.streamdeck.multiactions.routine2` | Multi Switch |
-| 4 | 0 | `com.elgato.streamdeck.multiactions.random` | Random Action |
+| 4 | 0 | `com.elgato.streamdeck.page.indicator` (app-rendered) | Page Indicator |
 | 0 | 1 | `com.elgato.streamdeck.keys.logic` | Key Logic |
 | 1 | 1 | `com.elgato.streamdeck.multiactions.delay` | Delay |
 | 2 | 1 | `com.elgato.streamdeck.system.digitaltime` | Digital Time |
 | 3 | 1 | `com.elgato.streamdeck.keys.adaptor` | Key Adaptor |
 | 4 | 1 | `com.elgato.streamdeck.keys.stack` | Key Stack |
 | 0 | 2 | `com.elgato.streamdeck.page` (nav) | ← Prev Page |
-| 1 | 2 | `com.elgato.streamdeck.system.pagination` | Pagination |
+| 1 | 2 | `com.elgato.streamdeck.multiactions.random` | Random Action |
+| 2 | 2 | `com.elgato.streamdeck.system.pagination` | Pagination |
 | 4 | 2 | `com.elgato.streamdeck.page` (nav) | Next Page → |
 
 ## Action Types Requiring GUI Capture
 
-These action types cannot be placed via JSON injection alone — their schema is incomplete or they require right-click gestures:
+These action types cannot be placed via JSON injection alone — their schema is incomplete or they require right-click gestures. Use the `drive-windows-gui` skill for all of these.
 
-| Action | Reason | Subagent task |
-|--------|--------|---------------|
-| Create Folder | Requires sub-profile structure the app creates on placement; JSON-only placement is silently dropped by the app on save-back | Drag-drop via streamdeck-driver, export, diff manifest |
-| Pinned Action | Right-click → Pin gesture only | Capture manifest after pinning |
-| Wallpaper | Right-click → Set from file | Capture manifest after set |
-| Multi Action with custom title+icon | Engine sets display incorrectly | Compare GUI-placed vs engine-placed manifests |
+| Action | UUID | Status | Reason | Subagent task |
+|--------|------|--------|--------|---------------|
+| Create Folder | `com.elgato.streamdeck.profile.openchild` | ❌ Not captured | Requires sub-profile structure the app creates on placement; JSON-only placement is silently dropped | Drag-drop onto Page 3, export manifest, diff against engine-generated |
+| Pinned Action | unknown | ❌ Not captured | Right-click → Pin gesture only; no JSON equivalent | Right-click any button → Pin, export, read manifest |
+| Wallpaper | unknown | ❌ Not captured | Right-click → Set Wallpaper from file | Right-click canvas → Set Wallpaper, export, read manifest |
+| Multi Action title+icon | `com.elgato.streamdeck.multiactions.routine` | ❌ Not captured | Engine-placed Multi Action renders display incorrectly vs GUI-placed | Place via GUI, export, diff `States` and `Settings` vs engine output |
+
+After capturing each schema, document the discovered fields in `docs/obsidian-vault/` and add to `expand-reference-profile.js` where applicable.
 
 Use the `streamdeck-driver` subagent for these. After capture, diff the exported manifest against an engine-generated one to identify the missing fields.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ---
 title: Changelog
 description: All notable changes to opendeck-factory
-version: 2.0.0
+version: 2.1.0
 created: 2026-04-22T00:00:00Z
 last_updated: 2026-04-22T00:00:00Z
 ---
@@ -14,6 +14,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: 
 ---
 
 ## [Unreleased]
+
+## [2.1.0] — 2026-04-22
+
+### Features
+- MCP server (`src/mcp-server.js`) with 7 tools via stdio transport: `extract_profile`, `pack_profile`, `validate_profile`, `list_profile`, `add_shortcut`, `generate_icons`, `list_shortcuts`
+- Claude Code plugin scaffold (`.claude-plugin/`): `plugin.json`, `marketplace.json`, pre-pack-validate hook
+- Reference profile: white border ring (square outer, rounded inner corners via SVG evenodd), Page 5 for Neo & Plus device-specific actions, brighter page colors across all 5 pages
+
+### Documentation
+- Sync SKILL.md reference tables to live 5-page profile layout
+
+### Bug Fixes
+- Guard `PAGE5_UUID` write with `existsSync` to prevent ENOENT on missing page directory
+
+---
 
 ## [2.0.0] — 2026-04-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,23 @@ auto-converts to Apache 2.0 two years after each release. See LICENSE and NOTICE
 - Profile generation workflow: `.claude/skills/generate-profile/SKILL.md`
 - Capture reference profile (all action types): `.claude/skills/capture-streamdeck-reference/SKILL.md`
 - Drive Windows GUI (Stream Deck app): `.claude/skills/drive-windows-gui/SKILL.md`
+
+## MCP Server
+
+`src/mcp-server.js` — 7 tools: `extract_profile`, `pack_profile`, `validate_profile`, `list_profile`, `add_shortcut`, `generate_icons`, `list_shortcuts`.
+
+**Claude Desktop config** (`claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "opendeck": {
+      "command": "node",
+      "args": ["C:/Users/romar/projects/opendeck/opendeck-factory/src/mcp-server.js"]
+    }
+  }
+}
+```
+
+## Claude Code Plugin
+
+`.claude-plugin/plugin.json` — bundles MCP server + skills for Claude Code plugin marketplace distribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "FSL-1.1-ALv2",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "adm-zip": "^0.5.17"
       },
       "devDependencies": {
@@ -305,6 +306,56 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
@@ -342,6 +393,18 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
@@ -354,7 +417,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -364,6 +426,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -401,6 +479,64 @@
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -453,6 +589,26 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -491,6 +647,38 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cosmiconfig": {
@@ -536,6 +724,43 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -548,11 +773,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -572,6 +823,33 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -581,17 +859,106 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -603,6 +970,50 @@
         }
       ]
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -610,6 +1021,41 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/git-raw-commits": {
@@ -643,6 +1089,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -656,6 +1162,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/import-fresh": {
@@ -693,6 +1214,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "node_modules/ini": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
@@ -700,6 +1226,22 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arrayish": {
@@ -738,6 +1280,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -745,6 +1297,14 @@
       "dev": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -774,8 +1334,12 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -819,6 +1383,22 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -831,6 +1411,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -838,6 +1452,57 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/parent-module": {
@@ -870,11 +1535,92 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -889,7 +1635,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -903,6 +1648,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -913,6 +1678,149 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-width": {
@@ -950,6 +1858,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -971,6 +1900,36 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -987,6 +1946,11 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -1022,6 +1986,22 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepare": "make install-hooks"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "adm-zip": "^0.5.17"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendeck-factory",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "description": "Open-source Stream Deck profile editor engine",
   "main": "src/index.js",

--- a/scripts/expand-reference-profile.js
+++ b/scripts/expand-reference-profile.js
@@ -8,7 +8,6 @@ import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { deflateSync } from 'zlib';
-import { contrastColor } from '../src/colors.js';
 
 const APPDATA = process.env.APPDATA;
 const PLUGINS = 'C:/Program Files/Elgato/StreamDeck/plugins';
@@ -22,21 +21,24 @@ const PAGE_UUIDS = {
   2: '564D9B5B-CFDC-4129-95CF-5B3961B283BA',
   3: 'C3F9ED85-4D3E-4E56-96AD-148975110E6D',
   4: '9BF4637A-6E09-4FFB-A1E4-E7AA22066883',
+  5: 'D9C12A0B-08CC-43F0-8922-CFFC663B18B1',
 };
 
 const PAGE_COLORS = {
-  1: '#1464F4', // Electric blue    — System / OS control
-  2: '#F07800', // Vivid orange     — Stream Deck hardware
-  3: '#00B84A', // Vivid emerald    — Navigation / wayfinding
-  4: '#8B2BE2', // Vivid violet     — Soundboard + Multi Action
+  1: '#1A6EFF', // Electric blue    — System / OS control
+  2: '#FF8800', // Vivid orange     — Stream Deck hardware
+  3: '#00CC52', // Vivid emerald    — Navigation / wayfinding
+  4: '#A535F5', // Vivid violet     — Soundboard + Multi Action
+  5: '#64748B', // Slate gray       — Neo & Plus (Stream Deck Neo + Stream Deck Plus/Plus XL)
 };
 
 // Nav corners use the adjacent page's color so you can see where you're going
 const ADJACENT = {
-  1: { prev: PAGE_COLORS[4], next: PAGE_COLORS[2], prevN: 4, nextN: 2 },
+  1: { prev: PAGE_COLORS[5], next: PAGE_COLORS[2], prevN: 5, nextN: 2 },
   2: { prev: PAGE_COLORS[1], next: PAGE_COLORS[3], prevN: 1, nextN: 3 },
   3: { prev: PAGE_COLORS[2], next: PAGE_COLORS[4], prevN: 2, nextN: 4 },
-  4: { prev: PAGE_COLORS[3], next: PAGE_COLORS[1], prevN: 3, nextN: 1 },
+  4: { prev: PAGE_COLORS[3], next: PAGE_COLORS[5], prevN: 3, nextN: 5 },
+  5: { prev: PAGE_COLORS[4], next: PAGE_COLORS[1], prevN: 4, nextN: 1 },
 };
 
 // Icon map: key → { plugin directory base, icon filename }
@@ -79,7 +81,6 @@ const ICON = {
   keyLogic:         { p: 'com.elgato.streamdeck.keys',                 f: 'btn_keyLogic.svg' },
   keyAdaptor:       { p: 'com.elgato.streamdeck.keys',                 f: 'btn_keyAdaptor.svg' },
   keyStack:         { p: 'com.elgato.streamdeck.keys',                 f: 'btn_keyStack.svg' },
-  parentFolder:     { p: 'com.elgato.streamdeck.profile.backtoparent', f: 'btn_backtoParent.svg' },
   delay:            { p: 'com.elgato.streamdeck.multiactions',         f: 'btn_duration.svg' },
   digitalTime:      { p: 'com.elgato.streamdeck.system.digitaltime',   f: 'btn_digitalTime.svg' },
   pagination:       { p: 'com.elgato.streamdeck.system.pagination',    f: 'btn_pagination.svg' },
@@ -158,21 +159,49 @@ function buildIconLayer(key) {
   return `<g ${attrs.join(' ')}>${inner}</g>`;
 }
 
-// Icon-only SVG: no background rect — page background provides the color.
-// Used for all content buttons.
-function writeIconOnly(imagesDir, key) {
+const RX = 18;
+const BORDER_W = 5;
+const INNER = 144 - BORDER_W * 2; // 134px inner area
+
+function darkenColor(hex, amount = 0.3) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const dr = Math.max(0, Math.round(r * (1 - amount)));
+  const dg = Math.max(0, Math.round(g * (1 - amount)));
+  const db = Math.max(0, Math.round(b * (1 - amount)));
+  return `#${dr.toString(16).padStart(2, '0')}${dg.toString(16).padStart(2, '0')}${db.toString(16).padStart(2, '0')}`;
+}
+
+// Gradient fills the entire 144×144 canvas (app clips outer corners).
+// White ring drawn on top of gradient, under the icon — visible inside the app's own mask.
+// BORDER_W controls ring thickness; half the stroke falls outside SVG edge and gets clipped.
+function buttonDefs(color) {
+  const top = lightenColor(color, 0.35);
+  const bot = darkenColor(color, 0.30);
+  return `<defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="${top}"/><stop offset="100%" stop-color="${bot}"/></linearGradient></defs>`;
+}
+
+// Square outer corners, rounded inner corners.
+// Outer path fills full 144×144; inner path (with rx arcs) punches out the center via evenodd.
+function borderRing() {
+  const bw = BORDER_W, r = RX;
+  const x0 = bw, y0 = bw, x1 = 144 - bw, y1 = 144 - bw;
+  const inner = `M${x0+r} ${y0} L${x1-r} ${y0} A${r} ${r} 0 0 1 ${x1} ${y0+r} L${x1} ${y1-r} A${r} ${r} 0 0 1 ${x1-r} ${y1} L${x0+r} ${y1} A${r} ${r} 0 0 1 ${x0} ${y1-r} L${x0} ${y0+r} A${r} ${r} 0 0 1 ${x0+r} ${y0} Z`;
+  return `<path fill="white" fill-rule="evenodd" d="M0 0 H144 V144 H0 Z ${inner}"/>`;
+}
+
+function writeIconOnly(imagesDir, key, bgColor) {
   const layer = buildIconLayer(key);
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 144 144">\n${layer}\n</svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 144 144">\n${buttonDefs(bgColor)}\n<rect width="144" height="144" fill="url(#g)"/>\n${borderRing()}\n${layer}\n</svg>`;
   writeFileSync(join(imagesDir, `${key}.svg`), svg);
   return `Images/${key}.svg`;
 }
 
-// Nav composite: solid adjacent-page-color rect + icon.
-// Filename encodes color so prev (e.g. violet) and next (e.g. orange) don't collide.
 function writeNavComposite(imagesDir, key, color) {
   const layer = buildIconLayer(key);
   const slug = color.replace('#', '');
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 144 144">\n<rect width="144" height="144" fill="${color}"/>\n${layer}\n</svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 144 144">\n${buttonDefs(color)}\n<rect width="144" height="144" fill="url(#g)"/>\n${borderRing()}\n${layer}\n</svg>`;
   writeFileSync(join(imagesDir, `nav-${key}-${slug}.svg`), svg);
   return `Images/nav-${key}-${slug}.svg`;
 }
@@ -193,7 +222,7 @@ function btn(actionUUID, pluginUUID, pluginName, settings, label, image, bgColor
       ShowTitle: true,
       Title: label + '\n',
       TitleAlignment: 'bottom',
-      TitleColor: contrastColor(bgColor),
+      TitleColor: '#ffffff',
       FontSize: 9,
     }],
     UUID: actionUUID,
@@ -201,7 +230,7 @@ function btn(actionUUID, pluginUUID, pluginName, settings, label, image, bgColor
 }
 
 // Page Indicator: fully dynamic — app draws live page number on page background color.
-// No composite image; States:[{}] lets the page background show through.
+// ShowTitle:false + Title:'' suppresses any user-label text below the dynamic number.
 function makePageIndicator() {
   return {
     ActionID: randomUUID(),
@@ -211,9 +240,20 @@ function makePageIndicator() {
     Resources: null,
     Settings: {},
     State: 0,
-    States: [{}],
+    States: [{ ShowTitle: false, Title: '' }],
     UUID: 'com.elgato.streamdeck.page.indicator',
   };
+}
+
+// Returns a lighter (more vivid on dark background) version of a hex color.
+function lightenColor(hex, amount = 0.35) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const lr = Math.min(255, Math.round(r + (255 - r) * amount));
+  const lg = Math.min(255, Math.round(g + (255 - g) * amount));
+  const lb = Math.min(255, Math.round(b + (255 - b) * amount));
+  return `#${lr.toString(16).padStart(2, '0')}${lg.toString(16).padStart(2, '0')}${lb.toString(16).padStart(2, '0')}`;
 }
 
 // ── Page factory ──────────────────────────────────────────────────────────────
@@ -227,7 +267,7 @@ function buildPage(pageNum, defs) {
 
   const actions = {};
   for (const [col, row, iconKey, aUUID, pUUID, pName, settings, label] of defs) {
-    const image = writeIconOnly(imagesDir, iconKey);
+    const image = writeIconOnly(imagesDir, iconKey, color);
     actions[`${col},${row}`] = btn(aUUID, pUUID, pName, settings, label, image, color);
   }
 
@@ -237,13 +277,15 @@ function buildPage(pageNum, defs) {
   return { actions, imagesDir };
 }
 
-// Nav corners colored with the adjacent page's color (circular).
+// Nav corners: adjacent page color lightened so they pop against the current page background.
 function addNavCorners(actions, imagesDir, pageNum) {
   const { prev, next, prevN, nextN } = ADJACENT[pageNum];
-  const prevImage = writeNavComposite(imagesDir, 'navPrev', prev);
-  const nextImage = writeNavComposite(imagesDir, 'navNext', next);
-  actions['0,2'] = btn('com.elgato.streamdeck.page.previous', 'com.elgato.streamdeck.page', 'Pages', {}, `← ${prevN}`, prevImage, prev);
-  actions['4,2'] = btn('com.elgato.streamdeck.page.next',     'com.elgato.streamdeck.page', 'Pages', {}, `${nextN} →`, nextImage, next);
+  const prevLight = lightenColor(prev);
+  const nextLight = lightenColor(next);
+  const prevImage = writeNavComposite(imagesDir, 'navPrev', prevLight);
+  const nextImage = writeNavComposite(imagesDir, 'navNext', nextLight);
+  actions['0,2'] = btn('com.elgato.streamdeck.page.previous', 'com.elgato.streamdeck.page', 'Pages', {}, `← ${prevN}`, prevImage, prevLight);
+  actions['4,2'] = btn('com.elgato.streamdeck.page.next',     'com.elgato.streamdeck.page', 'Pages', {}, `${nextN} →`, nextImage, nextLight);
 }
 
 // ── Page 1 — System (electric blue) ──────────────────────────────────────────
@@ -289,34 +331,41 @@ addNavCorners(page2, imgDir2, 2);
 
 // ── Page 3 — Navigation (vivid emerald) ──────────────────────────────────────
 // Row 0: Switch Profile | Go to Page | · | · | [Page Indicator]
-// Row 1: Parent Folder
 // Row 2: [← 2:orange] | · | · | · | [4→:violet]
 // Create Folder: GUI-only (sub-profile structure required)
+// Parent Folder: removed — only valid inside a sub-folder, confusing at root level
 const { actions: page3, imagesDir: imgDir3 } = buildPage(3, [
-  [0, 0, 'switchProfile', 'com.elgato.streamdeck.profile.rotate',       'com.elgato.streamdeck.profile.rotate',       'Switch Profile', {}, 'Switch\nProfile'],
-  [1, 0, 'gotoPage',      'com.elgato.streamdeck.page.goto',            'com.elgato.streamdeck.page',                 'Pages',          { page: 0 }, 'Go to\nPage'],
-  [0, 1, 'parentFolder',  'com.elgato.streamdeck.profile.backtoparent', 'com.elgato.streamdeck.profile.backtoparent', 'Parent Folder',  {}, 'Parent\nFolder'],
+  [0, 0, 'switchProfile', 'com.elgato.streamdeck.profile.rotate', 'com.elgato.streamdeck.profile.rotate', 'Switch Profile', {}, 'Switch\nProfile'],
+  [1, 0, 'gotoPage',      'com.elgato.streamdeck.page.goto',      'com.elgato.streamdeck.page',           'Pages',          { page: 0 }, 'Go to\nPage'],
 ]);
 addNavCorners(page3, imgDir3, 3);
 
 // ── Page 4 — Soundboard + Multi Action + Keys (vivid violet) ─────────────────
 // Row 0: Play Audio | Stop Audio | Multi Action | Multi Switch | [Page Indicator]
-// Row 1: Key Logic | Delay | Digital Time | Key Adaptor | Key Stack
-// Row 2: [← 3:green] | Random Action | Pagination | · | [1→:blue]
+// Row 1: Key Logic | Delay | · | · | ·
+// Row 2: [← 3:green] | Random Action | · | · | [5→:slate]
 const { actions: page4, imagesDir: imgDir4 } = buildPage(4, [
-  [0, 0, 'playAudio',    'com.elgato.streamdeck.soundboard.playaudio',     'com.elgato.streamdeck.soundboard',         'Soundboard',   {}, 'Play\nAudio'],
-  [1, 0, 'stopAudio',    'com.elgato.streamdeck.soundboard.stopaudioplay', 'com.elgato.streamdeck.soundboard',         'Soundboard',   {}, 'Stop\nAudio'],
-  [2, 0, 'multiAction',  'com.elgato.streamdeck.multiactions.routine',     'com.elgato.streamdeck.multiactions',       'Multi Action', { Actions: [] }, 'Multi\nAction'],
-  [3, 0, 'multiSwitch',  'com.elgato.streamdeck.multiactions.routine2',    'com.elgato.streamdeck.multiactions',       'Multi Action', {}, 'Multi\nSwitch'],
-  [0, 1, 'keyLogic',     'com.elgato.streamdeck.keys.logic',               'com.elgato.streamdeck.keys',               'Keys',         {}, 'Key\nLogic'],
-  [1, 1, 'delay',        'com.elgato.streamdeck.multiactions.delay',       'com.elgato.streamdeck.multiactions',       'Multi Action', { duration: 1000 }, 'Delay'],
-  [2, 1, 'digitalTime',  'com.elgato.streamdeck.system.digitaltime',       'com.elgato.streamdeck.system.digitaltime', 'Digital Time', {}, 'Digital\nTime'],
-  [3, 1, 'keyAdaptor',   'com.elgato.streamdeck.keys.adaptor',             'com.elgato.streamdeck.keys',               'Keys',         {}, 'Key\nAdaptor'],
-  [4, 1, 'keyStack',     'com.elgato.streamdeck.keys.stack',               'com.elgato.streamdeck.keys',               'Keys',         {}, 'Key\nStack'],
-  [1, 2, 'randomAction', 'com.elgato.streamdeck.multiactions.random',      'com.elgato.streamdeck.multiactions',       'Multi Action', {}, 'Random\nAction'],
-  [2, 2, 'pagination',   'com.elgato.streamdeck.system.pagination',        'com.elgato.streamdeck.system.pagination',  'Pagination',   {}, 'Pagination'],
+  [0, 0, 'playAudio',    'com.elgato.streamdeck.soundboard.playaudio',     'com.elgato.streamdeck.soundboard',   'Soundboard',   {}, 'Play\nAudio'],
+  [1, 0, 'stopAudio',    'com.elgato.streamdeck.soundboard.stopaudioplay', 'com.elgato.streamdeck.soundboard',   'Soundboard',   {}, 'Stop\nAudio'],
+  [2, 0, 'multiAction',  'com.elgato.streamdeck.multiactions.routine',     'com.elgato.streamdeck.multiactions', 'Multi Action', { Actions: [] }, 'Multi\nAction'],
+  [3, 0, 'multiSwitch',  'com.elgato.streamdeck.multiactions.routine2',    'com.elgato.streamdeck.multiactions', 'Multi Action', {}, 'Multi\nSwitch'],
+  [0, 1, 'keyLogic',     'com.elgato.streamdeck.keys.logic',               'com.elgato.streamdeck.keys',         'Keys',         {}, 'Key\nLogic'],
+  [1, 1, 'delay',        'com.elgato.streamdeck.multiactions.delay',       'com.elgato.streamdeck.multiactions', 'Multi Action', { duration: 1000 }, 'Delay'],
+  [1, 2, 'randomAction', 'com.elgato.streamdeck.multiactions.random',      'com.elgato.streamdeck.multiactions', 'Multi Action', {}, 'Random\nAction'],
 ]);
 addNavCorners(page4, imgDir4, 4);
+
+// ── Page 5 — Neo & Plus (slate gray) ─────────────────────────────────────────
+// Row 0: Digital Time (Neo) | Pagination (Neo) | · | · | [Page Indicator]
+// Row 1: Key Adaptor (SD+/Plus XL) | Key Stack (SD+/Plus XL) | · | · | ·
+// Row 2: [← 4:violet] | · | · | · | [1→:blue]
+const { actions: page5, imagesDir: imgDir5 } = buildPage(5, [
+  [0, 0, 'digitalTime', 'com.elgato.streamdeck.system.digitaltime',      'com.elgato.streamdeck.system.digitaltime', 'Digital Time', {}, 'Digital\nTime'],
+  [1, 0, 'pagination',  'com.elgato.streamdeck.system.pagination',       'com.elgato.streamdeck.system.pagination',  'Pagination',   {}, 'Pagination'],
+  [0, 1, 'keyAdaptor',  'com.elgato.streamdeck.keys.adaptor',            'com.elgato.streamdeck.keys',               'Keys',         {}, 'Key\nAdaptor'],
+  [1, 1, 'keyStack',    'com.elgato.streamdeck.keys.stack',              'com.elgato.streamdeck.keys',               'Keys',         {}, 'Key\nStack'],
+]);
+addNavCorners(page5, imgDir5, 5);
 
 // ── Write page manifests ──────────────────────────────────────────────────────
 const pageData = [
@@ -324,6 +373,7 @@ const pageData = [
   { n: 2, uuid: PAGE_UUIDS[2], name: 'Stream Deck',                   actions: page2 },
   { n: 3, uuid: PAGE_UUIDS[3], name: 'Navigation',                    actions: page3 },
   { n: 4, uuid: PAGE_UUIDS[4], name: 'Soundboard + Multi Act + Keys', actions: page4 },
+  { n: 5, uuid: PAGE_UUIDS[5], name: 'Neo & Plus',                     actions: page5 },
 ];
 
 for (const { n, uuid, name, actions } of pageData) {
@@ -337,12 +387,11 @@ for (const { n, uuid, name, actions } of pageData) {
   console.log(`Page ${n} (${name}): ${Object.keys(actions).length} buttons → ${manifestPath}`);
 }
 
-// Clear stray content from old page 5 (D9C12A0B) if the directory still exists
-const PAGE5_UUID = 'D9C12A0B-08CC-43F0-8922-CFFC663B18B1';
-const page5Dir = join(PROFILE_ROOT, 'Profiles', PAGE5_UUID);
-if (existsSync(page5Dir)) {
-  writeFileSync(join(page5Dir, 'manifest.json'), JSON.stringify({ Controllers: [{ Actions: null, Type: 'Keypad' }], Icon: '', Name: '' }));
-  console.log('Page 5 (blank): cleared stray buttons');
-}
+// Update root manifest — register all 5 pages in order
+const rootPath = join(PROFILE_ROOT, 'manifest.json');
+const root = JSON.parse(readFileSync(rootPath, 'utf8'));
+root.Pages.Pages = Object.values(PAGE_UUIDS).map(u => u.toLowerCase());
+writeFileSync(rootPath, JSON.stringify(root));
+console.log('Root manifest: updated to 5 pages');
 
 console.log('\nDone. Start Stream Deck app and validate the profile.');

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+// MCP server for opendeck-factory — exposes 7 tools via stdio transport.
+// Usage: node src/mcp-server.js
+// Claude Desktop config: { "command": "node", "args": ["<abs-path>/src/mcp-server.js"] }
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { resolve, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { extract } from './extract.js';
+import { pack } from './pack.js';
+import { validate } from './validate.js';
+import { ProfileEditor } from './profile.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const server = new McpServer({
+  name: 'opendeck-factory',
+  version: JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).version,
+});
+
+// ── Tool 1: extract_profile ───────────────────────────────────────────────────
+server.tool(
+  'extract_profile',
+  'Extract a .streamDeckProfile ZIP to an editable directory',
+  {
+    profile_path: z.string().describe('Absolute path to the .streamDeckProfile file'),
+    output_dir: z.string().describe('Absolute path to the output directory'),
+  },
+  async ({ profile_path, output_dir }) => {
+    try {
+      extract(resolve(profile_path), resolve(output_dir));
+      return { content: [{ type: 'text', text: `Extracted to: ${output_dir}` }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Tool 2: pack_profile ──────────────────────────────────────────────────────
+server.tool(
+  'pack_profile',
+  'Pack an extracted profile directory back to a .streamDeckProfile ZIP',
+  {
+    source_dir: z.string().describe('Absolute path to the extracted profile directory'),
+    output_path: z.string().describe('Absolute path for the output .streamDeckProfile file'),
+  },
+  async ({ source_dir, output_path }) => {
+    try {
+      pack(resolve(source_dir), resolve(output_path));
+      return { content: [{ type: 'text', text: `Packed to: ${output_path}` }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Tool 3: validate_profile ──────────────────────────────────────────────────
+server.tool(
+  'validate_profile',
+  'Validate an extracted profile directory — checks structure, manifests, image refs, and grid bounds',
+  {
+    source_dir: z.string().describe('Absolute path to the extracted profile directory'),
+  },
+  async ({ source_dir }) => {
+    try {
+      const result = validate(resolve(source_dir));
+      if (result.valid) {
+        return { content: [{ type: 'text', text: 'Validation passed.' }] };
+      }
+      return {
+        content: [{ type: 'text', text: `Validation failed:\n${result.errors.map(e => `  - ${e}`).join('\n')}` }],
+        isError: true,
+      };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Tool 4: list_profile ──────────────────────────────────────────────────────
+server.tool(
+  'list_profile',
+  'Show the button grid layout of an extracted profile — all pages, rows, and button labels',
+  {
+    source_dir: z.string().describe('Absolute path to the extracted profile directory'),
+  },
+  async ({ source_dir }) => {
+    try {
+      const editor = new ProfileEditor(resolve(source_dir));
+      const { cols, rows } = editor.deviceInfo;
+      const lines = [];
+
+      lines.push(`Profile: "${editor.profileManifest.Name}"`);
+      lines.push(`Device: ${editor.deviceInfo.name} (${cols}x${rows})`);
+
+      for (const pageUUID of editor.getPageUUIDs()) {
+        const manifest = editor.getPageManifest(pageUUID);
+        lines.push(`\nPage: "${manifest.Name || '(unnamed)'}" [${pageUUID}]`);
+
+        const actions = editor.getActions(pageUUID);
+        if (!actions || Object.keys(actions).length === 0) {
+          lines.push('  (empty)');
+          continue;
+        }
+
+        for (let row = 0; row < rows; row++) {
+          const cells = [];
+          for (let col = 0; col < cols; col++) {
+            const action = actions[`${col},${row}`];
+            const title = action ? (action.States?.[0]?.Title || '').replace(/\n/g, ' ').trim() : '---';
+            cells.push(title.padEnd(14));
+          }
+          lines.push(`  Row ${row}: | ${cells.join(' | ')} |`);
+        }
+      }
+
+      return { content: [{ type: 'text', text: lines.join('\n') }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Tool 5: add_shortcut ──────────────────────────────────────────────────────
+server.tool(
+  'add_shortcut',
+  'Add a hotkey button to a profile page at a specific grid position',
+  {
+    source_dir: z.string().describe('Absolute path to the extracted profile directory'),
+    page_uuid: z.string().describe('Page UUID (get from list_profile)'),
+    col: z.number().int().min(0).describe('Column (0-indexed)'),
+    row: z.number().int().min(0).describe('Row (0-indexed)'),
+    label: z.string().describe('Button label (use \\n for line breaks, max 3 lines)'),
+    key: z.string().describe('Key name (e.g. "A", "F5", "UP", "ENTER") — must be in KEY_CODES'),
+    ctrl: z.boolean().optional().describe('Ctrl modifier'),
+    shift: z.boolean().optional().describe('Shift modifier'),
+    alt: z.boolean().optional().describe('Alt modifier'),
+    win: z.boolean().optional().describe('Win/Cmd modifier'),
+    image_path: z.string().optional().describe('Absolute path to a 144x144 icon image (PNG or SVG)'),
+  },
+  async ({ source_dir, page_uuid, col, row, label, key, ctrl, shift, alt, win, image_path }) => {
+    try {
+      const editor = new ProfileEditor(resolve(source_dir));
+      editor.addHotkeyButton(page_uuid, col, row, {
+        label, key, ctrl, shift, alt, win,
+        imagePath: image_path ? resolve(image_path) : undefined,
+      });
+      editor.save();
+      return { content: [{ type: 'text', text: `Added "${label}" (${key}) at ${col},${row} on page ${page_uuid}` }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Tool 6: generate_icons ────────────────────────────────────────────────────
+server.tool(
+  'generate_icons',
+  'Generate color-coded SVG icons for all shortcuts in a data/shortcuts/<app>.json file',
+  {
+    app_name: z.string().describe('App name matching the shortcuts file (e.g. "vs-code")'),
+    shortcuts_dir: z.string().optional().describe('Directory containing shortcuts JSON files (default: <repo-root>/data/shortcuts/)'),
+    icons_dir: z.string().optional().describe('Output directory for icons (default: <repo-root>/data/icons/<app-name>/)'),
+  },
+  async ({ app_name, shortcuts_dir, icons_dir }) => {
+    try {
+      const env = { ...process.env };
+      const args = [join(ROOT, 'scripts/generate-icons.js'), app_name];
+      if (shortcuts_dir) env.SHORTCUTS_DIR = resolve(shortcuts_dir);
+      if (icons_dir) env.ICONS_DIR = resolve(icons_dir);
+
+      const output = execFileSync(process.execPath, args, { cwd: ROOT, env, encoding: 'utf8' });
+      return { content: [{ type: 'text', text: output.trim() }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Tool 7: list_shortcuts ────────────────────────────────────────────────────
+server.tool(
+  'list_shortcuts',
+  'Read and return the shortcut definitions for an app from data/shortcuts/<app>.json',
+  {
+    app_name: z.string().describe('App name (e.g. "vs-code")'),
+    shortcuts_dir: z.string().optional().describe('Directory containing shortcuts JSON files (default: <repo-root>/data/shortcuts/)'),
+  },
+  async ({ app_name, shortcuts_dir }) => {
+    try {
+      const dir = shortcuts_dir ? resolve(shortcuts_dir) : join(ROOT, 'data/shortcuts');
+      const filePath = join(dir, `${app_name}.json`);
+      if (!existsSync(filePath)) {
+        return { content: [{ type: 'text', text: `Shortcuts file not found: ${filePath}` }], isError: true };
+      }
+      const data = JSON.parse(readFileSync(filePath, 'utf8'));
+      const lines = [`App: ${data.app || app_name}`, `Shortcuts: ${data.shortcuts?.length ?? 0}`];
+      for (const s of data.shortcuts || []) {
+        lines.push(`  [${s.category}] ${s.command}: ${s.key}${s.modifiers ? ` (${Object.entries(s.modifiers).filter(([,v]) => v).map(([k]) => k).join('+')})` : ''}`);
+      }
+      return { content: [{ type: 'text', text: lines.join('\n') }] };
+    } catch (err) {
+      return { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Start ─────────────────────────────────────────────────────────────────────
+const transport = new StdioServerTransport();
+await server.connect(transport);


### PR DESCRIPTION
## Summary

- **MCP server** (`src/mcp-server.js`): 7 tools via stdio transport — extract, pack, validate, list, add_shortcut, generate_icons, list_shortcuts
- **Claude Code plugin** (`.claude-plugin/`): plugin.json, marketplace.json, pre-pack-validate hook — free distribution tier for the catalog funnel
- **Reference profile redesign**: white border ring (square outer / rounded inner via SVG evenodd), Page 5 for Neo & Plus device-specific actions, brighter page colors, 5-page circular nav

## Test plan

- [ ] `node src/mcp-server.js` starts without error (stdio)
- [ ] Claude Desktop config wired — all 7 tools appear in tool list
- [ ] `validate_profile` returns pass on `profiles/vs-code`
- [ ] `list_profile` returns readable grid for `profiles/vs-code`
- [ ] Reference profile loads in Stream Deck app — 5 pages, gradients, white borders, Page Indicator

## Release

Bumps `package.json` → `2.1.0`, CHANGELOG entry added.
Tag `v2.1.0` to be applied on master after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Retroactive linkage (added 2026-04-24):** Closes #3, Closes #8, Closes #10