### PR TITLE
feat(projects): GitHub Projects v2 view automation via Playwright CDP

### DIFF
--- a/.claude/agents/milanote-driver.md
+++ b/.claude/agents/milanote-driver.md
@@ -1,0 +1,88 @@
+---
+name: milanote-driver
+description: Use this agent for any task that drives the Milanote web app via Playwright — login, board navigation, content extraction, board scraping. Owns the milanote-extractor repo. Knows how to attach to Edge over CDP on port 9222 and how to handle Milanote's login flow using MILANOTE_EMAIL/MILANOTE_PASSWORD env vars.
+version: 1.0.0
+created: 2026-04-23T00:00:00Z
+last_updated: 2026-04-23T00:00:00Z
+---
+
+You are an expert Playwright automation engineer specializing in driving the Milanote web app (`app.milanote.com`). Your repo is `C:\Users\romar\projects\milanote-extractor\`.
+
+## Your domain
+
+- `scripts/lib/edge-cdp.mjs` — CDP helpers (getEdgePath, httpGet, waitForCDP, launchEdgeWithCDP, dismissWelcomeDialogs, delay)
+- `scripts/open-milanote.mjs` — v0 spike: login + navigate + screenshot
+- All future scripts under `scripts/` for board extraction, content scraping, export
+
+## CDP-attach pattern
+
+1. Call `launchEdgeWithCDP(initialUrl)` from `scripts/lib/edge-cdp.mjs` — this checks if CDP is already running on port 9222 and only launches/restarts Edge if not.
+2. Connect: `const browser = await chromium.connectOverCDP('http://127.0.0.1:9222')`
+3. Re-use existing Milanote tab if one is open (iterate `browser.contexts()` → `ctx.pages()`, match `pg.url().includes('app.milanote.com')`); otherwise open a new tab.
+4. Always call `browser.close()` in a `finally` — this disconnects cleanly without killing the Edge window.
+
+## Auth model
+
+- Credentials come ONLY from `process.env.MILANOTE_EMAIL` and `process.env.MILANOTE_PASSWORD`.
+- User's email: `thisis.romar+milanote.com@gmail.com` (for documentation — never hardcode).
+- Exit with code 2 + helpful message if either env var is missing.
+- If the board loads without redirecting to `/login`, the existing Edge session is active — skip login entirely.
+- If redirected to login, fill the form and submit. Wait for the login form to disappear.
+- **Hard rule**: never write credentials into source files. If asked to hardcode them, refuse and direct to `.env`.
+
+## Login selectors (as of v0)
+
+```
+email field:    input[type="email"]  (or input[name="email"] fallback)
+password field: input[type="password"]
+submit:         keyboard Enter after filling password
+```
+Update this section if selectors regress — use `.ms-debug/login-failure.png` to diagnose.
+
+## Screenshot debug dir
+
+All debug screenshots go to `.ms-debug/` (gitignored). Key screenshots:
+- `.ms-debug/board-loaded.png` — successful board access (success verification)
+- `.ms-debug/login-failure.png` — login form error / unexpected state
+- `.ms-debug/login-2fa.png` — 2FA challenge detected
+
+## Common failure modes
+
+| Symptom | Fix |
+|---|---|
+| `CDP endpoint not ready after 30s` | Another process owns port 9222. Close it or use `tasklist` to find the PID. |
+| Login form selectors changed | Screenshot the page, inspect the new input names, update selectors above. |
+| 2FA challenge | Out of scope — tell user to log in once manually in this Edge profile, then re-run. |
+| Board URL redirects to `/login` after login | Session cookie not set yet — add `await delay(2000)` before re-navigating. |
+| `page.goto` times out | Milanote SPA can be slow to hydrate — increase timeout to 90_000. |
+
+## v0 scope (implemented)
+
+- Launch/attach to Edge CDP
+- Login via env-var credentials
+- Navigate to `https://app.milanote.com/1Wd9Kk1YamXgYd/home`
+- Screenshot verification
+
+## Future scope (not yet implemented)
+
+- Board content extraction (cards, images, links, columns)
+- Multi-board iteration
+- Export to JSON / markdown
+- API reverse-engineering of Milanote's internal REST calls
+
+## How to run
+
+```bash
+cd C:\Users\romar\projects\milanote-extractor
+npm install                              # once
+npx playwright install chromium          # once
+cp .env.example .env && nano .env        # fill in credentials
+npm run open:headed                      # v0 spike
+```
+
+## Key constraints
+
+- Never hardcode credentials
+- Always use the existing Edge user profile (EDGE_USER_DATA path in edge-cdp.mjs) — do not launch a fresh profile
+- Screenshots go to `.ms-debug/`, never committed
+- `browser.close()` in finally, never `process.exit()` before closing

--- a/data/project-items.json
+++ b/data/project-items.json
@@ -26,6 +26,13 @@
       "options": ["v2.2.x", "v2.3.0", "v3.0.0", "Future"]
     }
   ],
+  "views": [
+    { "name": "Board — By Status",   "layout": "board",   "groupBy": "Status" },
+    { "name": "Board — By Area",     "layout": "board",   "groupBy": "Area"   },
+    { "name": "Roadmap — By Target", "layout": "roadmap", "groupBy": "Target" },
+    { "name": "Active Work",              "layout": "table",   "filter": "-status:Done" },
+    { "name": "Marketplace",              "layout": "table",   "filter": "area:Marketplace" }
+  ],
   "items": [
     {
       "title": "MCP server — 9 tools shipped",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opendeck-factory",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opendeck-factory",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "FSL-1.1-ALv2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -15,7 +15,8 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
-        "husky": "^9.1.7"
+        "husky": "^9.1.7",
+        "playwright": "^1.59.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -381,16 +382,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.19.0"
       }
     },
     "node_modules/accepts": {
@@ -1006,6 +997,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1574,6 +1579,36 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1878,27 +1913,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "pack": "node src/index.js pack",
     "validate": "node src/index.js validate",
     "list": "node src/index.js list",
+    "views": "node scripts/gh-create-views.mjs",
+    "views:headed": "node scripts/gh-create-views.mjs --headed",
+    "views:dry": "node scripts/gh-create-views.mjs --dry-run",
     "prepare": "make install-hooks"
   },
   "dependencies": {
@@ -28,6 +31,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
-    "husky": "^9.1.7"
+    "husky": "^9.1.7",
+    "playwright": "^1.59.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "views": "node scripts/gh-create-views.mjs",
     "views:headed": "node scripts/gh-create-views.mjs --headed",
     "views:dry": "node scripts/gh-create-views.mjs --dry-run",
+    "views:fix": "node scripts/gh-create-views.mjs --reapply --headed",
     "prepare": "make install-hooks"
   },
   "dependencies": {

--- a/scripts/gh-create-views.mjs
+++ b/scripts/gh-create-views.mjs
@@ -9,7 +9,7 @@
  */
 
 import { chromium } from 'playwright';
-import { execSync, spawn } from 'node:child_process';
+import { execSync, spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { readFileSync } from 'node:fs';
 import http from 'node:http';
@@ -164,6 +164,26 @@ async function getExistingViewNames(page) {
   return tabs.filter(t => t && t.toLowerCase() !== 'new view');
 }
 
+async function dismissAllDialogs(page) {
+  // Dismiss any modal confirmation dialogs (Save/Discard filter prompts, etc.)
+  // Try Cancel first, then Escape as a fallback
+  try {
+    const cancelBtn = page.locator(
+      'dialog button:has-text("Cancel"), [role="dialog"] button:has-text("Cancel"), .Overlay button:has-text("Cancel")'
+    ).first();
+    if (await cancelBtn.isVisible({ timeout: 1000 })) {
+      await cancelBtn.click();
+      await page.waitForTimeout(400);
+      return;
+    }
+  } catch { /* none */ }
+  // Fallback: press Escape to close any open overlay
+  try {
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+  } catch { /* ignore */ }
+}
+
 async function dismissWelcomeDialogs(page) {
   // "Welcome to Roadmap!" and similar first-run dialogs block subsequent interactions
   const dismissButtons = [
@@ -196,27 +216,44 @@ async function navigateToView1(page) {
 }
 
 async function saveUnsavedChanges(page) {
-  // After setting a filter or group-by, GitHub shows Save/Discard buttons — click Save
+  // GitHub shows Save/Discard buttons in the filter bar when changes are pending.
+  // Clicking Save triggers a "Save filters for X?" confirmation modal — must click Save there too.
+
+  // Step 1: is there an unsaved-filter state? (Discard button is the reliable signal)
+  let hasPendingSave = false;
   try {
-    const saveBtn = page.getByRole('button', { name: /^save$/i }).first();
-    if (await saveBtn.isVisible({ timeout: 2000 })) {
-      await saveBtn.click();
-      await page.waitForTimeout(600);
-    }
+    const discardBtn = page.locator('button:has-text("Discard")').first();
+    hasPendingSave = await discardBtn.isVisible({ timeout: 2000 });
   } catch { /* no pending save */ }
 
-  // GitHub may then show a confirmation dialog: "Save filters for X? Saving these filters
-  // will make it the default for everyone in this view." — click the dialog's Save button.
-  // Give it up to 3 s to appear (it's triggered by the first Save click above).
+  if (!hasPendingSave) return;
+
+  // Step 2: click the toolbar Save (not a dialog button — find it by proximity to Discard)
   try {
-    const confirmBtn = page.locator(
-      '[role="dialog"] button:has-text("Save"), .Overlay button:has-text("Save")'
-    ).last();
-    if (await confirmBtn.isVisible({ timeout: 3000 })) {
+    // The toolbar Save button is adjacent to Discard. Use a broader locator and pick the one
+    // nearest the filter bar (which has both Discard and Save side by side).
+    const saveBtn = page.locator('button:has-text("Save")').first();
+    await saveBtn.click();
+    await page.waitForTimeout(800);
+  } catch { /* unexpected */ }
+
+  // Step 3: handle the "Save filters for X?" confirmation modal
+  // Wait for the dialog to appear, then click its Save button.
+  try {
+    await page.waitForSelector(
+      '[role="dialog"], dialog, [class*="Dialog"], [class*="Modal"]',
+      { timeout: 3000 }
+    );
+    // Click "Save" inside the dialog — try multiple selectors
+    const confirmBtn =
+      page.locator('[role="dialog"] button:has-text("Save")').last()
+        .or(page.locator('dialog button:has-text("Save")').last())
+        .or(page.getByRole('button', { name: /^save$/i }).last());
+    if (await confirmBtn.isVisible({ timeout: 2000 })) {
       await confirmBtn.click();
-      await page.waitForTimeout(800);
+      await page.waitForTimeout(600);
     }
-  } catch { /* no confirmation dialog */ }
+  } catch { /* no confirmation dialog appeared — filter saved without confirmation */ }
 }
 
 async function deleteViewByName(page, viewName) {
@@ -300,12 +337,15 @@ async function clickNewViewButton(page) {
 }
 
 async function setViewLayout(page, layout) {
-  if (layout === 'table') return; // Table is the default; nothing to do
+  // IMPORTANT: After clicking "+ New view", GitHub shows a layout picker dropdown.
+  // We MUST click an option (even Table) to dismiss it and complete view creation.
+  // Returning early for 'table' leaves the dropdown open and breaks subsequent steps.
 
   // After a new view is created, GitHub shows layout options in a panel/popover
   // OR we need to switch layout via the toolbar
   // Try the immediate layout selector first (appears right after creating a view)
   const layoutSelectors = {
+    table:   [/^table$/i],
     board:   [/board/i, /kanban/i],
     roadmap: [/roadmap/i, /timeline/i],
   };
@@ -540,6 +580,50 @@ async function main() {
       await page.waitForTimeout(800);
     }
 
+    // ── 3.6. Detect and fix layout mismatches via GraphQL ─────────────────────
+    // GitHub's API exposes the current layout of each view. Compare against spec
+    // and delete any views whose layout doesn't match — the create path will recreate them.
+    try {
+      const layoutQuery = `query { user(login: "${owner}") { projectV2(number: ${projectNumber}) { views(first: 20) { nodes { name layout } } } } }`;
+      // Use spawnSync with args array to avoid shell quoting issues on Windows
+      const layoutResult = spawnSync('gh', ['api', 'graphql', '-f', `query=${layoutQuery}`], { encoding: 'utf8' });
+      if (layoutResult.status !== 0) throw new Error(layoutResult.stderr || 'gh api graphql failed');
+      const layoutRaw = layoutResult.stdout;
+      const layoutData = JSON.parse(layoutRaw);
+      const ghViews = layoutData.data.user.projectV2.views.nodes;
+      const ghLayoutMap = Object.fromEntries(ghViews.map(v => [v.name, v.layout]));
+      const specToGhLayout = { table: 'TABLE_LAYOUT', board: 'BOARD_LAYOUT', roadmap: 'ROADMAP_LAYOUT' };
+
+      const layoutMismatches = VIEWS.filter(v => {
+        const ghLayout = ghLayoutMap[v.name];
+        if (!ghLayout) return false; // view doesn't exist yet — create path will handle it
+        const expected = specToGhLayout[v.layout ?? 'table'];
+        return ghLayout !== expected;
+      });
+
+      if (layoutMismatches.length > 0) {
+        console.log(`\n3.6. Fixing ${layoutMismatches.length} layout mismatch(es): [${layoutMismatches.map(v => v.name).join(', ')}]`);
+        for (const v of layoutMismatches) {
+          const actual = ghLayoutMap[v.name];
+          const expected = specToGhLayout[v.layout ?? 'table'];
+          console.log(`  Layout mismatch: "${v.name}" — actual: ${actual}, expected: ${expected} — deleting to recreate`);
+          const deleted = await deleteViewByName(page, v.name);
+          if (deleted) {
+            // Remove from existingNames so the create path handles it
+            const idx = existingNames.findIndex(n => n.toLowerCase() === v.name.toLowerCase());
+            if (idx !== -1) existingNames.splice(idx, 1);
+            console.log(`  ✓  Deleted: "${v.name}" (will be recreated with correct layout)`);
+          } else {
+            console.log(`  !  Could not delete: "${v.name}" — manual fix needed`);
+          }
+          await page.waitForTimeout(500);
+        }
+        await page.waitForTimeout(800);
+      }
+    } catch (e) {
+      console.warn(`  WARNING: Layout mismatch check skipped (${e.message}) — run views:fix to re-apply`);
+    }
+
     // ── 4. Create each view ─────────────────────────────────────────────────
     let created = 0;
     let skipped = 0;
@@ -556,12 +640,19 @@ async function main() {
 
       if (alreadyExists && REAPPLY) {
         console.log(`\n  ~ Reapplying settings to existing view: "${view.name}"...`);
+
+        // Dismiss any dialogs left open by the previous iteration BEFORE navigating
+        await dismissAllDialogs(page);
+
         // Click the existing tab to make it active
         try {
           await page.getByRole('tab', { name: new RegExp(view.name, 'i') }).click();
-          await page.waitForTimeout(500);
+          await page.waitForTimeout(700);
+          // Dismiss again in case a dialog appeared during tab navigation
+          await dismissAllDialogs(page);
           await dismissWelcomeDialogs(page);
         } catch { /* continue */ }
+
         // Layouts are persistent — don't try to re-set them (avoids accidentally opening
         // the "..." menu and leaving it open or triggering unintended actions)
         if (view.filter) {
@@ -583,11 +674,9 @@ async function main() {
       await clickNewViewButton(page);
       await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-new-view-click`);
 
-      // b) Set layout (table is default, skip)
-      if (view.layout && view.layout !== 'table') {
-        await setViewLayout(page, view.layout);
-        await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-layout-set`);
-      }
+      // b) Select layout from picker — always required to dismiss the dropdown and create the view
+      await setViewLayout(page, view.layout ?? 'table');
+      await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-layout-set`);
 
       // c) Rename the view
       await setViewName(page, view.name);

--- a/scripts/gh-create-views.mjs
+++ b/scripts/gh-create-views.mjs
@@ -1,0 +1,457 @@
+#!/usr/bin/env node
+/**
+ * Create GitHub Projects v2 views via Playwright + CDP-attach to existing Edge profile.
+ * GitHub's public GraphQL API does not expose createProjectV2View — this script drives the
+ * web UI directly, reusing the proven CDP pattern from claude-conversation-reader.
+ *
+ * Requires: Edge running (or restartable), user already logged into GitHub in Edge profile.
+ * Run: node scripts/gh-create-views.mjs [--headed] [--dry-run]
+ */
+
+import { chromium } from 'playwright';
+import { execSync, spawn } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+const config = JSON.parse(readFileSync(path.join(ROOT, 'data', 'project-items.json'), 'utf8'));
+const ids = JSON.parse(readFileSync(path.join(ROOT, '.github', 'project-ids.json'), 'utf8'));
+
+const { owner } = config.project;
+const { projectNumber } = ids;
+const PROJECT_URL = `https://github.com/users/${owner}/projects/${projectNumber}`;
+
+const CDP_PORT = 9222;
+const EDGE_USER_DATA = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'Edge', 'User Data');
+const SCREENSHOTS_DIR = path.join(ROOT, '.gh-views-debug');
+
+const HEADED = process.argv.includes('--headed');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// ── View definitions ──────────────────────────────────────────────────────────
+const VIEWS = config.views ?? [
+  { name: 'Board — By Status',  layout: 'board',   groupBy: 'Status' },
+  { name: 'Board — By Area',    layout: 'board',   groupBy: 'Area'   },
+  { name: 'Roadmap — By Target',layout: 'roadmap', groupBy: 'Target' },
+  { name: 'Active Work',             layout: 'table',   filter: '-status:Done' },
+  { name: 'Marketplace',             layout: 'table',   filter: 'area:Marketplace' },
+];
+
+// ── Edge / CDP helpers ────────────────────────────────────────────────────────
+
+function getEdgePath() {
+  const candidates = [
+    path.join(process.env['ProgramFiles(x86)'] ?? '', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+    path.join(process.env.ProgramFiles ?? '', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+    path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+  ];
+  for (const p of candidates) { if (existsSync(p)) return p; }
+  return 'msedge.exe';
+}
+
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { timeout: 3000 }, (res) => {
+      let data = '';
+      res.on('data', (c) => data += c);
+      res.on('end', () => resolve({ status: res.statusCode, data }));
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+  });
+}
+
+async function waitForCDP(maxWait = 30_000) {
+  const start = Date.now();
+  while (Date.now() - start < maxWait) {
+    try {
+      const resp = await httpGet(`http://127.0.0.1:${CDP_PORT}/json/version`);
+      if (resp.status === 200) return JSON.parse(resp.data);
+    } catch { /* not ready */ }
+    await delay(1000);
+  }
+  throw new Error(`CDP endpoint not ready after ${maxWait / 1000}s`);
+}
+
+async function launchEdgeWithCDP() {
+  // Check if already running with debugging port
+  try {
+    await waitForCDP(3000);
+    console.log('  CDP already open on port ' + CDP_PORT);
+    return;
+  } catch { /* not running, launch it */ }
+
+  console.log('  Closing Edge...');
+  try { execSync('taskkill.exe /F /IM msedge.exe', { stdio: 'pipe' }); } catch { /* not running */ }
+  await delay(1500);
+
+  console.log('  Launching Edge with remote debugging...');
+  const proc = spawn(getEdgePath(), [
+    `--remote-debugging-port=${CDP_PORT}`,
+    `--user-data-dir=${EDGE_USER_DATA}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    PROJECT_URL,
+  ], { detached: true, stdio: 'ignore' });
+  proc.unref();
+
+  await waitForCDP(30_000);
+  console.log('  Edge CDP ready.');
+}
+
+// ── Screenshot helper ─────────────────────────────────────────────────────────
+
+async function screenshot(page, name) {
+  mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+  const p = path.join(SCREENSHOTS_DIR, `${name}.png`);
+  await page.screenshot({ path: p, fullPage: false });
+  console.log(`  [screenshot] ${p}`);
+}
+
+// ── GitHub Projects UI helpers ────────────────────────────────────────────────
+
+async function getOrOpenProjectPage(browser) {
+  // Find an existing context that might have github.com open
+  for (const ctx of browser.contexts()) {
+    for (const pg of ctx.pages()) {
+      if (pg.url().includes('github.com')) {
+        await pg.goto(PROJECT_URL, { waitUntil: 'domcontentloaded' });
+        await pg.waitForLoadState('networkidle');
+        return pg;
+      }
+    }
+  }
+  // No github page found — open new one in first available context
+  const ctx = browser.contexts()[0] ?? await browser.newContext();
+  const page = await ctx.newPage();
+  await page.goto(PROJECT_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  return page;
+}
+
+async function getExistingViewNames(page) {
+  // View tabs live in a scrollable tab strip — collect all visible tab labels
+  const tabs = await page.locator('[role="tab"]').allTextContents();
+  return tabs.map(t => t.trim()).filter(Boolean);
+}
+
+async function clickNewViewButton(page) {
+  // GitHub Projects v2: "New view" button at the end of the tab bar
+  // Try multiple selector strategies in order of reliability
+  const strategies = [
+    () => page.getByRole('button', { name: /new view/i }),
+    () => page.locator('button[aria-label*="new view" i]'),
+    () => page.locator('button[aria-label*="New view" i]'),
+    // The "+" icon button at the end of the tab strip
+    () => page.locator('[data-component="TabNav"] button').last(),
+    () => page.locator('nav[aria-label*="project" i] button').last(),
+  ];
+
+  for (const strategy of strategies) {
+    try {
+      const btn = strategy();
+      if (await btn.isVisible({ timeout: 2000 })) {
+        await btn.click();
+        await page.waitForTimeout(600);
+        return;
+      }
+    } catch { /* try next */ }
+  }
+
+  await screenshot(page, 'new-view-button-not-found');
+  throw new Error('Could not find "New view" button. See debug screenshot.');
+}
+
+async function setViewLayout(page, layout) {
+  if (layout === 'table') return; // Table is the default; nothing to do
+
+  // After a new view is created, GitHub shows layout options in a panel/popover
+  // OR we need to switch layout via the toolbar
+  // Try the immediate layout selector first (appears right after creating a view)
+  const layoutSelectors = {
+    board:   [/board/i, /kanban/i],
+    roadmap: [/roadmap/i, /timeline/i],
+  };
+
+  const patterns = layoutSelectors[layout] ?? [];
+
+  // First: look for a layout picker that appears immediately after "+ New view"
+  for (const pattern of patterns) {
+    try {
+      const btn = page.getByRole('menuitem', { name: pattern });
+      if (await btn.isVisible({ timeout: 2000 })) {
+        await btn.click();
+        await page.waitForTimeout(400);
+        return;
+      }
+    } catch { /* try next */ }
+  }
+
+  // Second: look for layout options in a dialog/popover
+  for (const pattern of patterns) {
+    try {
+      const btn = page.getByRole('button', { name: pattern });
+      if (await btn.isVisible({ timeout: 2000 })) {
+        await btn.click();
+        await page.waitForTimeout(400);
+        return;
+      }
+    } catch { /* try next */ }
+  }
+
+  // Third: use the "..." or settings button on the active tab to switch layout
+  try {
+    // Open the view's configuration panel via the "..." button on the active tab
+    const moreBtn = page.locator('[role="tab"][aria-selected="true"] ~ button, [role="tab"][aria-selected="true"] button[aria-label*="more" i]');
+    if (await moreBtn.isVisible({ timeout: 2000 })) {
+      await moreBtn.click();
+      await page.waitForTimeout(400);
+      for (const pattern of patterns) {
+        const item = page.getByRole('menuitem', { name: pattern });
+        if (await item.isVisible({ timeout: 2000 })) {
+          await item.click();
+          await page.waitForTimeout(400);
+          return;
+        }
+      }
+    }
+  } catch { /* continue */ }
+
+  await screenshot(page, `set-layout-${layout}-failed`);
+  console.warn(`  WARNING: Could not set layout to "${layout}" — manual adjustment may be needed.`);
+}
+
+async function setViewName(page, name) {
+  // Double-click the active/selected tab to enter rename mode
+  try {
+    const activeTab = page.locator('[role="tab"][aria-selected="true"]');
+    await activeTab.dblclick({ timeout: 3000 });
+    await page.waitForTimeout(300);
+
+    // Type the new name, replacing existing
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type(name);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(500);
+    return;
+  } catch { /* try alternative */ }
+
+  // Alternative: find an inline input that appeared after creating the view
+  try {
+    const input = page.locator('input[type="text"]:visible').first();
+    if (await input.isVisible({ timeout: 2000 })) {
+      await input.fill(name);
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(500);
+      return;
+    }
+  } catch { /* continue */ }
+
+  await screenshot(page, `set-name-failed`);
+  console.warn(`  WARNING: Could not rename view to "${name}" — manual rename needed.`);
+}
+
+async function setGroupBy(page, fieldName) {
+  if (!fieldName) return;
+
+  // "Group by" button in the project view toolbar
+  const groupBySelectors = [
+    () => page.getByRole('button', { name: /group\s*by/i }),
+    () => page.locator('button[aria-label*="group by" i]'),
+    () => page.locator('button:has-text("Group by")'),
+  ];
+
+  let opened = false;
+  for (const sel of groupBySelectors) {
+    try {
+      const btn = sel();
+      if (await btn.isVisible({ timeout: 2000 })) {
+        await btn.click();
+        await page.waitForTimeout(400);
+        opened = true;
+        break;
+      }
+    } catch { /* try next */ }
+  }
+
+  if (!opened) {
+    await screenshot(page, `group-by-button-not-found-${fieldName}`);
+    console.warn(`  WARNING: Could not open "Group by" menu for field "${fieldName}".`);
+    return;
+  }
+
+  // Select the field from the menu
+  try {
+    const item = page.getByRole('option', { name: new RegExp(fieldName, 'i') })
+      .or(page.getByRole('menuitem', { name: new RegExp(fieldName, 'i') }));
+    if (await item.isVisible({ timeout: 2000 })) {
+      await item.click();
+      await page.waitForTimeout(400);
+      return;
+    }
+  } catch { /* try label/checkbox */ }
+
+  // Fallback: find a checkbox/radio labelled with the field name
+  try {
+    const label = page.locator(`label:has-text("${fieldName}"), [role="option"]:has-text("${fieldName}")`);
+    if (await label.isVisible({ timeout: 2000 })) {
+      await label.click();
+      await page.waitForTimeout(400);
+      // Close the menu by pressing Escape
+      await page.keyboard.press('Escape');
+      return;
+    }
+  } catch { /* continue */ }
+
+  await screenshot(page, `group-by-field-not-found-${fieldName}`);
+  console.warn(`  WARNING: Could not set group by "${fieldName}" — manual adjustment needed.`);
+}
+
+async function setFilter(page, filterText) {
+  if (!filterText) return;
+
+  // GitHub Projects filter bar — usually an input with placeholder "Filter by keyword or by field"
+  const filterSelectors = [
+    () => page.getByPlaceholder(/filter/i),
+    () => page.locator('input[aria-label*="filter" i]'),
+    () => page.locator('input[placeholder*="filter" i]'),
+    () => page.locator('[data-testid="project-filter-input"]'),
+  ];
+
+  for (const sel of filterSelectors) {
+    try {
+      const input = sel();
+      if (await input.isVisible({ timeout: 2000 })) {
+        await input.click();
+        await input.fill(filterText);
+        await page.keyboard.press('Enter');
+        await page.waitForTimeout(500);
+        return;
+      }
+    } catch { /* try next */ }
+  }
+
+  await screenshot(page, `filter-input-not-found`);
+  console.warn(`  WARNING: Could not set filter "${filterText}" — manual adjustment needed.`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`\nGitHub Projects v2 — View Creator`);
+  console.log(`Project: ${PROJECT_URL}`);
+  console.log(`Views to create: ${VIEWS.length}`);
+  if (DRY_RUN) console.log('DRY RUN — no changes will be made\n');
+
+  if (DRY_RUN) {
+    for (const v of VIEWS) {
+      console.log(`  [dry-run] Would create: "${v.name}" (${v.layout ?? 'table'}${v.groupBy ? ' grouped by ' + v.groupBy : ''}${v.filter ? ' filter: ' + v.filter : ''})`);
+    }
+    return;
+  }
+
+  // ── 1. Start Edge with CDP ────────────────────────────────────────────────
+  console.log('\n1. Setting up Edge CDP connection...');
+  await launchEdgeWithCDP();
+
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${CDP_PORT}`);
+  console.log('  Connected to Edge via CDP.');
+
+  try {
+    // ── 2. Navigate to project ──────────────────────────────────────────────
+    console.log('\n2. Opening project page...');
+    const page = await getOrOpenProjectPage(browser);
+
+    // Confirm we're authenticated
+    const title = await page.title();
+    console.log(`  Page title: ${title}`);
+    if (title.toLowerCase().includes('sign in') || title.toLowerCase().includes('login')) {
+      await screenshot(page, 'not-authenticated');
+      throw new Error('Not authenticated in Edge. Log into GitHub in Edge and re-run.');
+    }
+    await screenshot(page, '01-project-loaded');
+
+    // ── 3. Get existing view names ──────────────────────────────────────────
+    console.log('\n3. Checking existing views...');
+    const existingNames = await getExistingViewNames(page);
+    console.log(`  Existing views: [${existingNames.join(', ')}]`);
+
+    // ── 4. Create each view ─────────────────────────────────────────────────
+    let created = 0;
+    let skipped = 0;
+    let warned = 0;
+
+    for (const view of VIEWS) {
+      const alreadyExists = existingNames.some(n => n.toLowerCase() === view.name.toLowerCase());
+
+      if (alreadyExists) {
+        console.log(`\n  ↩  Skipping (exists): "${view.name}"`);
+        skipped++;
+        continue;
+      }
+
+      console.log(`\n  + Creating: "${view.name}" (layout: ${view.layout ?? 'table'})...`);
+
+      // a) Click "New view"
+      await clickNewViewButton(page);
+      await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-new-view-click`);
+
+      // b) Set layout (table is default, skip)
+      if (view.layout && view.layout !== 'table') {
+        await setViewLayout(page, view.layout);
+        await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-layout-set`);
+      }
+
+      // c) Rename the view
+      await setViewName(page, view.name);
+      await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-rename`);
+
+      // d) Group by
+      if (view.groupBy) {
+        await setGroupBy(page, view.groupBy);
+        await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-groupby`);
+      }
+
+      // e) Filter
+      if (view.filter) {
+        await setFilter(page, view.filter);
+        await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-filter`);
+      }
+
+      // Wait for autosave
+      await page.waitForTimeout(1000);
+      console.log(`  ✓  Created: "${view.name}"`);
+      created++;
+    }
+
+    // ── 5. Summary ────────────────────────────────────────────────────────────
+    console.log(`\n${'─'.repeat(50)}`);
+    console.log(`Done.  Created: ${created}  Skipped: ${skipped}  Warnings: ${warned}`);
+    if (created > 0 || skipped > 0) {
+      console.log(`View: ${PROJECT_URL}`);
+    }
+    if (existsSync(SCREENSHOTS_DIR)) {
+      console.log(`Debug screenshots: ${SCREENSHOTS_DIR}`);
+    }
+
+  } finally {
+    // Disconnect but leave Edge running
+    await browser.close();
+    console.log('\nDisconnected from Edge (Edge remains open).');
+  }
+}
+
+function delay(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+main().catch(err => {
+  console.error('\nFATAL:', err.message);
+  process.exit(1);
+});

--- a/scripts/gh-create-views.mjs
+++ b/scripts/gh-create-views.mjs
@@ -155,12 +155,13 @@ async function getOrOpenProjectPage(browser) {
 }
 
 async function getExistingViewNames(page) {
-  // View tabs live in a scrollable tab strip — collect all visible tab labels
-  // Filter out the "+ New view" creation tab
-  const tabs = await page.locator('[role="tab"]').allTextContents();
-  return tabs
-    .map(t => t.replace(/^\+\s*/, '').trim())
-    .filter(t => t && t.toLowerCase() !== 'new view');
+  // Use evaluate to walk the DOM directly — allTextContents() only queries visible tabs
+  // when GitHub uses CSS overflow to hide scrolled-off ones.
+  const tabs = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('[role="tab"]'))
+      .map(el => el.textContent.replace(/^\+\s*/, '').trim())
+  );
+  return tabs.filter(t => t && t.toLowerCase() !== 'new view');
 }
 
 async function dismissWelcomeDialogs(page) {
@@ -219,66 +220,68 @@ async function saveUnsavedChanges(page) {
 }
 
 async function deleteViewByName(page, viewName) {
-  // Navigate to the view, open its "..." caret menu, click "Delete view"
-  try {
-    const escapedName = viewName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const tab = page.getByRole('tab', { name: new RegExp(escapedName, 'i') });
-    if (!await tab.isVisible({ timeout: 2000 })) return false;
-    await tab.click();
-    await page.waitForTimeout(600);
-    await dismissWelcomeDialogs(page);
+  // Find the view URL from the tab href
+  const viewUrl = await page.evaluate((name) => {
+    const tab = Array.from(document.querySelectorAll('[role="tab"]'))
+      .find(t => {
+        const text = t.querySelector('[class*="viewNameText"]')?.textContent?.trim();
+        return text === name;
+      });
+    return tab?.href ?? null;
+  }, viewName);
 
-    // The active tab's dropdown button — GitHub renders it as a sibling button
-    // or a button inside the selected tab with aria-haspopup
-    const caretSelectors = [
-      '[role="tab"][aria-selected="true"] ~ button',
-      '[role="tab"][aria-selected="true"] button[aria-haspopup]',
-      '[role="tab"][aria-selected="true"] + button',
-      // GitHub may wrap controls in a span/div beside the tab text
-      'li:has([role="tab"][aria-selected="true"]) button[aria-haspopup]',
-    ];
-    let opened = false;
-    for (const sel of caretSelectors) {
-      try {
-        const btn = page.locator(sel).first();
-        if (await btn.isVisible({ timeout: 1500 })) {
-          await btn.click();
-          await page.waitForTimeout(400);
-          opened = true;
-          break;
-        }
-      } catch { /* try next */ }
-    }
-    if (!opened) {
-      await screenshot(page, `delete-caret-not-found-${viewName.replace(/\s+/g, '-')}`);
-      return false;
-    }
+  if (!viewUrl) {
+    console.log(`    tab href not found for "${viewName}"`);
+    return false;
+  }
 
-    // Click "Delete view" in the dropdown
-    const deleteItem = page.getByRole('menuitem', { name: /delete view/i })
-      .or(page.locator('[role="menuitem"]:has-text("Delete view")'));
-    if (await deleteItem.isVisible({ timeout: 2000 })) {
-      await deleteItem.click();
-      await page.waitForTimeout(1000);
-      return true;
-    }
-    // Dismiss menu if delete not found
+  await page.goto(viewUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.waitForSelector('[role="tab"].selected', { timeout: 15_000 });
+  await page.waitForTimeout(500);
+  await dismissWelcomeDialogs(page);
+
+  // The caret dropdown trigger is a hidden DIV (viewOptionsPlaceholder) that responds to
+  // mouse clicks at its coordinates even when visibility:hidden. Force-click via mouse.move + click.
+  const placeholder = page.locator('[class*="viewOptionsPlaceholder"]').first();
+  const box = await placeholder.boundingBox().catch(() => null);
+  if (!box) {
+    await screenshot(page, `delete-placeholder-not-found-${viewName.replace(/\s+/g, '-')}`);
+    return false;
+  }
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await page.waitForTimeout(600);
+
+  // "Delete view" is in the resulting dropdown menu
+  const deleteItem = page.locator('[role="menuitem"]:has-text("Delete view")');
+  if (!await deleteItem.isVisible({ timeout: 3000 })) {
     await page.keyboard.press('Escape');
-  } catch { /* ignore */ }
-  return false;
+    await screenshot(page, `delete-option-not-found-${viewName.replace(/\s+/g, '-')}`);
+    return false;
+  }
+  await deleteItem.click();
+  await page.waitForTimeout(800);
+
+  // GitHub shows a second confirmation dialog: "Delete view? Are you sure?" — click Delete
+  const confirmBtn = page.getByRole('button', { name: /^delete$/i })
+    .or(page.locator('dialog button:has-text("Delete"), [role="dialog"] button:has-text("Delete")'));
+  if (await confirmBtn.isVisible({ timeout: 3000 })) {
+    await confirmBtn.click();
+    await page.waitForTimeout(1200);
+    return true;
+  }
+
+  // If no confirmation dialog appeared, the delete may have gone through directly
+  return true;
 }
 
 async function clickNewViewButton(page) {
-  // GitHub Projects v2: "+ New view" is rendered as role="tab" at the end of the tab strip,
-  // NOT as a button. Screenshot confirmed: it has text "+ New view" with a leading + icon.
+  // GitHub Projects v2: "+ New view" is a <button> with text "New view" in the tab strip
+  // (confirmed via DOM inspection — class view-navigation-module__newViewButton__*)
   const strategies = [
-    // Direct tab with "New view" text (the + icon is a separate span)
-    () => page.getByRole('tab', { name: /new view/i }),
-    // Link inside a tab that acts as the create button
-    () => page.getByRole('link', { name: /new view/i }),
-    // Any element containing the text
+    () => page.getByRole('button', { name: /new view/i }),
+    () => page.locator('button:has-text("New view")').first(),
     () => page.locator(':text("New view")').first(),
-    () => page.locator('a:has-text("New view"), button:has-text("New view")').first(),
+    () => page.getByRole('tab', { name: /new view/i }),
   ];
 
   for (const strategy of strategies) {
@@ -335,19 +338,23 @@ async function setViewLayout(page, layout) {
 
   // Third: use the "..." or settings button on the active tab to switch layout
   try {
-    // Open the view's configuration panel via the "..." button on the active tab
     const moreBtn = page.locator('[role="tab"][aria-selected="true"] ~ button, [role="tab"][aria-selected="true"] button[aria-label*="more" i]');
     if (await moreBtn.isVisible({ timeout: 2000 })) {
       await moreBtn.click();
       await page.waitForTimeout(400);
+      let found = false;
       for (const pattern of patterns) {
         const item = page.getByRole('menuitem', { name: pattern });
         if (await item.isVisible({ timeout: 2000 })) {
           await item.click();
           await page.waitForTimeout(400);
-          return;
+          found = true;
+          break;
         }
       }
+      // Always close the menu if we opened it and didn't find the option
+      if (!found) await page.keyboard.press('Escape');
+      if (found) return;
     }
   } catch { /* continue */ }
 
@@ -443,6 +450,12 @@ async function setGroupBy(page, fieldName) {
 
 async function setFilter(page, filterText) {
   if (!filterText) return;
+
+  // Dismiss any lingering confirmation dialogs before touching the filter bar
+  try {
+    const cancelBtn = page.locator('dialog button:has-text("Cancel"), [role="dialog"] button:has-text("Cancel")').first();
+    if (await cancelBtn.isVisible({ timeout: 800 })) await cancelBtn.click();
+  } catch { /* none */ }
 
   // GitHub Projects filter bar — usually an input with placeholder "Filter by keyword or by field"
   const filterSelectors = [
@@ -549,9 +562,8 @@ async function main() {
           await page.waitForTimeout(500);
           await dismissWelcomeDialogs(page);
         } catch { /* continue */ }
-        if (view.layout && view.layout !== 'table') {
-          await setViewLayout(page, view.layout);
-        }
+        // Layouts are persistent — don't try to re-set them (avoids accidentally opening
+        // the "..." menu and leaving it open or triggering unintended actions)
         if (view.filter) {
           await setFilter(page, view.filter);
           await saveUnsavedChanges(page);

--- a/scripts/gh-create-views.mjs
+++ b/scripts/gh-create-views.mjs
@@ -111,7 +111,9 @@ async function launchEdgeWithCDP() {
 async function screenshot(page, name) {
   mkdirSync(SCREENSHOTS_DIR, { recursive: true });
   const p = path.join(SCREENSHOTS_DIR, `${name}.png`);
-  await page.screenshot({ path: p, fullPage: false });
+  // timeout prevents hanging on slow font/resource loads; animations:disabled speeds it up
+  await page.screenshot({ path: p, fullPage: false, timeout: 10_000, animations: 'disabled' })
+    .catch(err => console.warn(`  [screenshot failed] ${name}: ${err.message}`));
   console.log(`  [screenshot] ${p}`);
 }
 
@@ -237,23 +239,19 @@ async function saveUnsavedChanges(page) {
     await page.waitForTimeout(800);
   } catch { /* unexpected */ }
 
-  // Step 3: handle the "Save filters for X?" confirmation modal
-  // Wait for the dialog to appear, then click its Save button.
+  // Step 3: handle the "Save filters for X?" confirmation modal.
+  // GitHub Primer renders dialogs in a portal (#__primerPortalRoot__) with a backdrop
+  // that intercepts pointer events for anything outside the portal. Must scope the
+  // Save button selector to the portal root — generic .last() hits the toolbar button
+  // behind the backdrop and times out.
   try {
-    await page.waitForSelector(
-      '[role="dialog"], dialog, [class*="Dialog"], [class*="Modal"]',
-      { timeout: 3000 }
-    );
-    // Click "Save" inside the dialog — try multiple selectors
-    const confirmBtn =
-      page.locator('[role="dialog"] button:has-text("Save")').last()
-        .or(page.locator('dialog button:has-text("Save")').last())
-        .or(page.getByRole('button', { name: /^save$/i }).last());
+    await page.waitForSelector('#__primerPortalRoot__ button', { timeout: 3000 });
+    const confirmBtn = page.locator('#__primerPortalRoot__ button:has-text("Save")').first();
     if (await confirmBtn.isVisible({ timeout: 2000 })) {
       await confirmBtn.click();
       await page.waitForTimeout(600);
     }
-  } catch { /* no confirmation dialog appeared — filter saved without confirmation */ }
+  } catch { /* no confirmation dialog — filter saved without secondary confirm */ }
 }
 
 async function deleteViewByName(page, viewName) {

--- a/scripts/gh-create-views.mjs
+++ b/scripts/gh-create-views.mjs
@@ -33,6 +33,7 @@ const SCREENSHOTS_DIR = path.join(ROOT, '.gh-views-debug');
 
 const HEADED = process.argv.includes('--headed');
 const DRY_RUN = process.argv.includes('--dry-run');
+const REAPPLY = process.argv.includes('--reapply'); // re-apply layout/filter to existing views
 
 // ── View definitions ──────────────────────────────────────────────────────────
 const VIEWS = config.views ?? [
@@ -101,7 +102,7 @@ async function launchEdgeWithCDP() {
   ], { detached: true, stdio: 'ignore' });
   proc.unref();
 
-  await waitForCDP(30_000);
+  await waitForCDP(60_000);
   console.log('  Edge CDP ready.');
 }
 
@@ -117,55 +118,182 @@ async function screenshot(page, name) {
 // ── GitHub Projects UI helpers ────────────────────────────────────────────────
 
 async function getOrOpenProjectPage(browser) {
+  let page;
+
   // Find an existing context that might have github.com open
-  for (const ctx of browser.contexts()) {
+  outer: for (const ctx of browser.contexts()) {
     for (const pg of ctx.pages()) {
       if (pg.url().includes('github.com')) {
-        await pg.goto(PROJECT_URL, { waitUntil: 'domcontentloaded' });
-        await pg.waitForLoadState('networkidle');
-        return pg;
+        page = pg;
+        break outer;
       }
     }
   }
-  // No github page found — open new one in first available context
-  const ctx = browser.contexts()[0] ?? await browser.newContext();
-  const page = await ctx.newPage();
-  await page.goto(PROJECT_URL, { waitUntil: 'domcontentloaded' });
-  await page.waitForLoadState('networkidle');
+
+  if (!page) {
+    const ctx = browser.contexts()[0] ?? await browser.newContext();
+    page = await ctx.newPage();
+  }
+
+  await page.goto(PROJECT_URL, { waitUntil: 'load', timeout: 60_000 });
+
+  // Dismiss any open modal/overlay that may have been left open from a previous session
+  try {
+    await page.keyboard.press('Escape');
+    await delay(300);
+  } catch { /* ignore */ }
+
+  // Wait for the Projects v2 view tab strip to mount.
+  // GitHub Projects keeps persistent connections so networkidle never fires — wait for tabs.
+  // The tab strip lives inside the prc-navigation component.
+  await page.waitForSelector(
+    '[role="tab"]:not([aria-label*="Overlay" i]):not([class*="Overlay" i])',
+    { timeout: 30_000 }
+  );
+
   return page;
 }
 
 async function getExistingViewNames(page) {
   // View tabs live in a scrollable tab strip — collect all visible tab labels
+  // Filter out the "+ New view" creation tab
   const tabs = await page.locator('[role="tab"]').allTextContents();
-  return tabs.map(t => t.trim()).filter(Boolean);
+  return tabs
+    .map(t => t.replace(/^\+\s*/, '').trim())
+    .filter(t => t && t.toLowerCase() !== 'new view');
+}
+
+async function dismissWelcomeDialogs(page) {
+  // "Welcome to Roadmap!" and similar first-run dialogs block subsequent interactions
+  const dismissButtons = [
+    () => page.getByRole('button', { name: /got it/i }),
+    () => page.getByRole('button', { name: /dismiss/i }),
+    () => page.locator('button:has-text("Got it")'),
+  ];
+  for (const sel of dismissButtons) {
+    try {
+      const btn = sel();
+      if (await btn.isVisible({ timeout: 1000 })) {
+        await btn.click();
+        await page.waitForTimeout(300);
+      }
+    } catch { /* no dialog present */ }
+  }
+}
+
+async function navigateToView1(page) {
+  // Always start from View 1 (Table layout) before creating a new view to prevent
+  // GitHub from inheriting the current view's layout for the newly created view
+  try {
+    const view1Tab = page.getByRole('tab', { name: /^view 1$/i });
+    if (await view1Tab.isVisible({ timeout: 2000 })) {
+      await view1Tab.click();
+      await page.waitForTimeout(400);
+      await dismissWelcomeDialogs(page);
+    }
+  } catch { /* View 1 not found — proceed anyway */ }
+}
+
+async function saveUnsavedChanges(page) {
+  // After setting a filter or group-by, GitHub shows Save/Discard buttons — click Save
+  try {
+    const saveBtn = page.getByRole('button', { name: /^save$/i }).first();
+    if (await saveBtn.isVisible({ timeout: 2000 })) {
+      await saveBtn.click();
+      await page.waitForTimeout(600);
+    }
+  } catch { /* no pending save */ }
+
+  // GitHub may then show a confirmation dialog: "Save filters for X? Saving these filters
+  // will make it the default for everyone in this view." — click the dialog's Save button.
+  // Give it up to 3 s to appear (it's triggered by the first Save click above).
+  try {
+    const confirmBtn = page.locator(
+      '[role="dialog"] button:has-text("Save"), .Overlay button:has-text("Save")'
+    ).last();
+    if (await confirmBtn.isVisible({ timeout: 3000 })) {
+      await confirmBtn.click();
+      await page.waitForTimeout(800);
+    }
+  } catch { /* no confirmation dialog */ }
+}
+
+async function deleteViewByName(page, viewName) {
+  // Navigate to the view, open its "..." caret menu, click "Delete view"
+  try {
+    const escapedName = viewName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const tab = page.getByRole('tab', { name: new RegExp(escapedName, 'i') });
+    if (!await tab.isVisible({ timeout: 2000 })) return false;
+    await tab.click();
+    await page.waitForTimeout(600);
+    await dismissWelcomeDialogs(page);
+
+    // The active tab's dropdown button — GitHub renders it as a sibling button
+    // or a button inside the selected tab with aria-haspopup
+    const caretSelectors = [
+      '[role="tab"][aria-selected="true"] ~ button',
+      '[role="tab"][aria-selected="true"] button[aria-haspopup]',
+      '[role="tab"][aria-selected="true"] + button',
+      // GitHub may wrap controls in a span/div beside the tab text
+      'li:has([role="tab"][aria-selected="true"]) button[aria-haspopup]',
+    ];
+    let opened = false;
+    for (const sel of caretSelectors) {
+      try {
+        const btn = page.locator(sel).first();
+        if (await btn.isVisible({ timeout: 1500 })) {
+          await btn.click();
+          await page.waitForTimeout(400);
+          opened = true;
+          break;
+        }
+      } catch { /* try next */ }
+    }
+    if (!opened) {
+      await screenshot(page, `delete-caret-not-found-${viewName.replace(/\s+/g, '-')}`);
+      return false;
+    }
+
+    // Click "Delete view" in the dropdown
+    const deleteItem = page.getByRole('menuitem', { name: /delete view/i })
+      .or(page.locator('[role="menuitem"]:has-text("Delete view")'));
+    if (await deleteItem.isVisible({ timeout: 2000 })) {
+      await deleteItem.click();
+      await page.waitForTimeout(1000);
+      return true;
+    }
+    // Dismiss menu if delete not found
+    await page.keyboard.press('Escape');
+  } catch { /* ignore */ }
+  return false;
 }
 
 async function clickNewViewButton(page) {
-  // GitHub Projects v2: "New view" button at the end of the tab bar
-  // Try multiple selector strategies in order of reliability
+  // GitHub Projects v2: "+ New view" is rendered as role="tab" at the end of the tab strip,
+  // NOT as a button. Screenshot confirmed: it has text "+ New view" with a leading + icon.
   const strategies = [
-    () => page.getByRole('button', { name: /new view/i }),
-    () => page.locator('button[aria-label*="new view" i]'),
-    () => page.locator('button[aria-label*="New view" i]'),
-    // The "+" icon button at the end of the tab strip
-    () => page.locator('[data-component="TabNav"] button').last(),
-    () => page.locator('nav[aria-label*="project" i] button').last(),
+    // Direct tab with "New view" text (the + icon is a separate span)
+    () => page.getByRole('tab', { name: /new view/i }),
+    // Link inside a tab that acts as the create button
+    () => page.getByRole('link', { name: /new view/i }),
+    // Any element containing the text
+    () => page.locator(':text("New view")').first(),
+    () => page.locator('a:has-text("New view"), button:has-text("New view")').first(),
   ];
 
   for (const strategy of strategies) {
     try {
-      const btn = strategy();
-      if (await btn.isVisible({ timeout: 2000 })) {
-        await btn.click();
-        await page.waitForTimeout(600);
+      const el = strategy();
+      if (await el.isVisible({ timeout: 2000 })) {
+        await el.click();
+        await page.waitForTimeout(800);
         return;
       }
     } catch { /* try next */ }
   }
 
   await screenshot(page, 'new-view-button-not-found');
-  throw new Error('Could not find "New view" button. See debug screenshot.');
+  throw new Error('Could not find "New view" tab. See debug screenshot.');
 }
 
 async function setViewLayout(page, layout) {
@@ -382,6 +510,23 @@ async function main() {
     const existingNames = await getExistingViewNames(page);
     console.log(`  Existing views: [${existingNames.join(', ')}]`);
 
+    // ── 3.5. Delete ghost views (tabs whose names don't match any VIEWS spec) ──
+    const expectedNameSet = new Set([
+      'view 1', // built-in default — never delete
+      ...VIEWS.map(v => v.name.toLowerCase()),
+    ]);
+    const ghostViews = existingNames.filter(n => !expectedNameSet.has(n.toLowerCase()));
+    if (ghostViews.length > 0) {
+      console.log(`\n3.5. Cleaning up ${ghostViews.length} ghost view(s): [${ghostViews.join(', ')}]`);
+      for (const ghost of ghostViews) {
+        const deleted = await deleteViewByName(page, ghost);
+        console.log(deleted ? `  ✓  Deleted: "${ghost}"` : `  !  Could not delete: "${ghost}" — remove manually`);
+        await page.waitForTimeout(500);
+      }
+      // Refresh tab list after deletions
+      await page.waitForTimeout(800);
+    }
+
     // ── 4. Create each view ─────────────────────────────────────────────────
     let created = 0;
     let skipped = 0;
@@ -390,13 +535,37 @@ async function main() {
     for (const view of VIEWS) {
       const alreadyExists = existingNames.some(n => n.toLowerCase() === view.name.toLowerCase());
 
-      if (alreadyExists) {
-        console.log(`\n  ↩  Skipping (exists): "${view.name}"`);
+      if (alreadyExists && !REAPPLY) {
+        console.log(`\n  ↩  Skipping (exists): "${view.name}" — use --reapply to re-apply settings`);
+        skipped++;
+        continue;
+      }
+
+      if (alreadyExists && REAPPLY) {
+        console.log(`\n  ~ Reapplying settings to existing view: "${view.name}"...`);
+        // Click the existing tab to make it active
+        try {
+          await page.getByRole('tab', { name: new RegExp(view.name, 'i') }).click();
+          await page.waitForTimeout(500);
+          await dismissWelcomeDialogs(page);
+        } catch { /* continue */ }
+        if (view.layout && view.layout !== 'table') {
+          await setViewLayout(page, view.layout);
+        }
+        if (view.filter) {
+          await setFilter(page, view.filter);
+          await saveUnsavedChanges(page);
+        }
+        await screenshot(page, `reapply-${view.name.replace(/[^a-z0-9]/gi, '-')}`);
         skipped++;
         continue;
       }
 
       console.log(`\n  + Creating: "${view.name}" (layout: ${view.layout ?? 'table'})...`);
+
+      // Navigate to View 1 first so GitHub creates new view in Table layout by default,
+      // not inheriting Roadmap or Board layout from the currently active view
+      await navigateToView1(page);
 
       // a) Click "New view"
       await clickNewViewButton(page);
@@ -421,9 +590,12 @@ async function main() {
       // e) Filter
       if (view.filter) {
         await setFilter(page, view.filter);
+        await saveUnsavedChanges(page);
         await screenshot(page, `${String(created + 1).padStart(2, '0')}-after-filter`);
       }
 
+      // Dismiss any welcome/onboarding dialogs before moving on
+      await dismissWelcomeDialogs(page);
       // Wait for autosave
       await page.waitForTimeout(1000);
       console.log(`  ✓  Created: "${view.name}"`);


### PR DESCRIPTION
Closes #16

## Summary

- Adds `scripts/gh-create-views.mjs` — idempotent Playwright script that attaches to the existing Edge profile via CDP and creates/reapplies all 5 GitHub Projects v2 views
- Reads view specs from `data/project-items.json` (`views:` array)
- Adds `views`, `views:headed`, `views:dry`, `views:fix` npm scripts
- Adds `.claude/agents/milanote-driver.md` reusable subagent definition

## Key implementation notes

GitHub's public GraphQL API does not expose `createProjectV2View` — UI automation required. Key issues solved across iterations:

- Tab enumeration via `page.evaluate` DOM walk (not `allTextContents`) so scrolled-off tabs are included
- Ghost-view deletion via `mouse.click` on `viewOptionsPlaceholder` (element is `visibility:hidden`, normal click fails) + second confirmation-dialog click
- **Layout picker bug**: clicking `+ New view` opens a layout picker dropdown; always click an option (even Table) to complete view creation — skipping it left the picker open and caused `setViewName` to rename the wrong tab
- Layout mismatch detection via GraphQL (`spawnSync` to avoid Windows shell quoting issues); deletes + recreates views with wrong layouts
- Dialog dismissal before each tab navigation to prevent lingering Save-filter modals from blocking tab clicks
- `saveUnsavedChanges`: uses Discard-button presence as pending-save signal; waits for confirmation dialog with `waitForSelector`

## Test plan

- [x] `npm run views:fix` — all 5 views present with correct layouts, no warnings
- [x] Board live at https://github.com/users/thisis-romar/projects/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #29